### PR TITLE
mark LockGuard type, irq Disable/Enable api, ISR function

### DIFF
--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -241,6 +241,7 @@ pub(super) unsafe fn init(base_register_vaddr: NonNull<u8>) {
         .call_once(|| SpinLock::new(unsafe { FaultEventRegisters::new(base_register_vaddr) }));
 }
 
+#[concur::ctxt(irq)]
 fn iommu_fault_handler(_frame: &TrapFrame) {
     let mut fault_event_regs = FAULT_EVENT_REGS.get().unwrap().lock();
 

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -52,6 +52,7 @@ impl IrqRemapping {
 
 // FIXME: Mark this as unsafe. See
 // <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
+#[concur::irq(enable)]
 pub(crate) fn enable_local() {
     x86_64::instructions::interrupts::enable();
     // When emulated with QEMU, interrupts may not be delivered if a STI instruction is immediately
@@ -68,6 +69,7 @@ pub(crate) fn enable_local() {
 //
 // FIXME: Mark this as unsafe. See
 // <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
+#[concur::irq(enable)]
 pub(crate) fn enable_local_and_halt() {
     // SAFETY:
     // 1. `sti` is safe to use because its safety requirement is upheld by the caller.
@@ -83,6 +85,7 @@ pub(crate) fn enable_local_and_halt() {
     };
 }
 
+#[concur::irq(disable)]
 pub(crate) fn disable_local() {
     x86_64::instructions::interrupts::disable();
 }

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -97,6 +97,7 @@ pub fn determine_tsc_freq_via_pit() -> u64 {
 
     return FREQUENCY.load(Ordering::Acquire);
 
+    #[concur::ctxt(irq)]
     fn pit_callback(trap_frame: &TrapFrame) {
         static IN_TIME: AtomicU64 = AtomicU64::new(0);
         static TSC_FIRST_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -135,6 +135,7 @@ fn init_periodic_mode_config() {
     // Disable PIT
     drop(irq);
 
+    #[concur::ctxt(irq)]
     fn pit_callback(_trap_frame: &TrapFrame) {
         static IN_TIME: AtomicU64 = AtomicU64::new(0);
         static APIC_FIRST_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/ostd/src/arch/x86/timer/mod.rs
+++ b/ostd/src/arch/x86/timer/mod.rs
@@ -60,6 +60,7 @@ pub(super) fn init_ap() {
     }
 }
 
+#[concur::ctxt(irq)]
 fn timer_callback(_: &TrapFrame) {
     let irq_guard = trap::irq::disable_local();
     if irq_guard.current_cpu() == CpuId::bsp() {

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -224,6 +224,7 @@ pub fn is_kernel_interrupted() -> bool {
 
 /// Handle traps (only from kernel).
 #[no_mangle]
+#[concur::ctxt(irq)]
 extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
     fn enable_local_if(cond: bool) {
         if cond {

--- a/ostd/src/smp.rs
+++ b/ostd/src/smp.rs
@@ -77,6 +77,7 @@ cpu_local! {
     static CALL_QUEUES: SpinLock<VecDeque<fn()>> = SpinLock::new(VecDeque::new());
 }
 
+#[concur::ctxt(irq)]
 fn do_inter_processor_call(_trapframe: &TrapFrame) {
     // No races because we are in IRQs.
     let this_cpu_id = crate::cpu::CpuId::current_racy();

--- a/ostd/src/task/preempt/guard.rs
+++ b/ostd/src/task/preempt/guard.rs
@@ -6,6 +6,7 @@ use crate::{sync::GuardTransfer, task::atomic_mode::InAtomicMode};
 #[clippy::has_significant_drop]
 #[must_use]
 #[derive(Debug)]
+#[concur::lock(no_preempt)]
 pub struct DisabledPreemptGuard {
     // This private field prevents user from constructing values of this type directly.
     _private: (),

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -222,6 +222,7 @@ pub fn disable_local() -> DisabledLocalIrqGuard {
 #[clippy::has_significant_drop]
 #[must_use]
 #[derive(Debug)]
+#[concur::lock(no_interrupt)]
 pub struct DisabledLocalIrqGuard {
     was_enabled: bool,
 }


### PR DESCRIPTION
**LockGuard**
- `#[concur::lock(no_interrupt)]` marks the lockguard type that disable interrupt while holding the lock
- `#[concur::lock(no_preempt)]` marks the lockguard type that disable preempt while holding the lock

**ISR Function**
- `#[concur::ctxt(irq)]` marks a function that may be called in IRQ context

**IRQ Api**
- `#[concur::irq(enable)]` marks a function that enables IRQ
- `#[concur::irq(disable)]` marks a function that disables IRQ