### PR TITLE
tag-asterinas: fix safety attribute syntax; `make rapx`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ virtio-net.pcap
 aster-nix-profile-*.json
 aster-nix-profile-*.folded
 aster-nix-profile-*.svg
+
+# RAPX
+data.sqlite3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "rust-analyzer.cargo.target": "x86_64-unknown-none",
     "rust-analyzer.check.extraEnv": {
-        "RUSTFLAGS": "--check-cfg cfg(ktest) --cfg ktest"
+        "RUSTFLAGS": "--check-cfg cfg(ktest) --cfg ktest -L/home/gh-zjp-CN/tag-std/safety-tool/target/safety-tool/lib --extern safety_macro -Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(rapx)"
     },
     "rust-analyzer.check.overrideCommand": [
         "cargo",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "rust-analyzer.cargo.target": "x86_64-unknown-none",
     "rust-analyzer.check.extraEnv": {
-        "RUSTFLAGS": "--check-cfg cfg(ktest) --cfg ktest -L/home/gh-zjp-CN/tag-std/safety-tool/target/safety-tool/lib --extern safety_macro -Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(rapx)"
+        "RUSTFLAGS": "--check-cfg cfg(ktest) --cfg ktest"
     },
     "rust-analyzer.check.overrideCommand": [
         "cargo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,7 @@ dependencies = [
  "ostd-pod",
  "ostd-test",
  "riscv",
+ "safety-lib",
  "sbi-rt",
  "smallvec",
  "spin",
@@ -1530,6 +1531,32 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "safety-lib"
+version = "0.2.1"
+source = "git+https://github.com/Artisan-Lab/tag-std?rev=4bdff279c921a7c765a747826f187b795db82a5b#4bdff279c921a7c765a747826f187b795db82a5b"
+dependencies = [
+ "safety-macro",
+]
+
+[[package]]
+name = "safety-macro"
+version = "0.2.0"
+source = "git+https://github.com/Artisan-Lab/tag-std?rev=4bdff279c921a7c765a747826f187b795db82a5b#4bdff279c921a7c765a747826f187b795db82a5b"
+dependencies = [
+ "safety-parser",
+]
+
+[[package]]
+name = "safety-parser"
+version = "0.2.0"
+source = "git+https://github.com/Artisan-Lab/tag-std?rev=4bdff279c921a7c765a747826f187b795db82a5b#4bdff279c921a7c765a747826f187b795db82a5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "sbi-rt"

--- a/Makefile
+++ b/Makefile
@@ -344,8 +344,7 @@ check: initramfs $(CARGO_OSDK)
 	@typos
 
 RAPX_EXIT_AND_EMIT ?= abort_and_emit
-RAPX_RUSTFLAGS ?= --check-cfg cfg(ktest) --cfg ktest -Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(rapx) \
-						 -L/home/gh-zjp-CN/tag-std/safety-tool/target/safety-tool/lib --extern safety_macro
+RAPX_RUSTFLAGS ?= --check-cfg cfg(ktest) --cfg ktest
 
 .PHONY: rapx
 rapx:

--- a/Makefile
+++ b/Makefile
@@ -344,12 +344,12 @@ check: initramfs $(CARGO_OSDK)
 	@typos
 
 RAPX_EXIT_AND_EMIT ?= abort_and_emit
-RAPX_RUSTFLAGS ?= --check-cfg cfg(ktest) --cfg ktest
+RAPX_RUSTFLAGS     ?= --check-cfg cfg(ktest) --cfg ktest
 
 .PHONY: rapx
 rapx:
 	# Currently only check ostd; ensure https://github.com/Artisan-Lab/tag-std is installed.
-	cd ostd && cargo clean && EXIT_AND_EMIT=$(RAPX_EXIT_AND_EMIT) RUSTFLAGS="$(RAPX_RUSTFLAGS)" cargo safety-tool --target x86_64-unknown-none
+	cd ostd && cargo clean && EXIT_AND_EMIT=$(RAPX_EXIT_AND_EMIT) RUSTFLAGS="$(RAPX_RUSTFLAGS)" cargo safety-tool --target x86_64-unknown-none $(RAPX_ARGS)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,15 @@ check: initramfs $(CARGO_OSDK)
 	@# Check typos
 	@typos
 
+RAPX_EXIT_AND_EMIT ?= abort_and_emit
+RAPX_RUSTFLAGS ?= --check-cfg cfg(ktest) --cfg ktest -Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(rapx) \
+						 -L/home/gh-zjp-CN/tag-std/safety-tool/target/safety-tool/lib --extern safety_macro
+
+.PHONY: rapx
+rapx:
+	# Currently only check ostd; ensure https://github.com/Artisan-Lab/tag-std is installed.
+	cd ostd && cargo clean && EXIT_AND_EMIT=$(RAPX_EXIT_AND_EMIT) RUSTFLAGS="$(RAPX_RUSTFLAGS)" cargo safety-tool --target x86_64-unknown-none
+
 .PHONY: clean
 clean:
 	@echo "Cleaning up Asterinas workspace target files"

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -38,6 +38,9 @@ unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu
 volatile = "0.6.1"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 
+# FIXME: change this to v0.2.1 once it's available on crates.io
+safety = { git = "https://github.com/Artisan-Lab/tag-std", rev = "4bdff279c921a7c765a747826f187b795db82a5b", package = "safety-lib" }
+
 [target.x86_64-unknown-none.dependencies]
 x86_64 = "0.14.13"
 x86 = "0.52.0"

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -225,7 +225,7 @@ unsafe fn wake_up_aps_via_mailbox(num_cpus: u32) {
 
     let offset = ap_boot_from_long_mode as usize - ap_boot_from_real_mode as usize;
 
-    let acpi_tables = get_acpi_tables().unwrap();
+    let acpi_tables = unsafe { get_acpi_tables().unwrap() };
     for ap_num in 1..num_cpus {
         wakeup_aps(
             &acpi_tables,

--- a/ostd/src/arch/x86/boot/smp.rs
+++ b/ostd/src/arch/x86/boot/smp.rs
@@ -52,7 +52,7 @@ use crate::{
 /// Safety:
 /// This function needs to be called after the OS initializes the ACPI table.
 pub(crate) unsafe fn count_processors() -> Option<u32> {
-    let acpi_tables = unsafe {get_acpi_tables()?};
+    let acpi_tables = unsafe { get_acpi_tables()? };
     let madt_table = acpi_tables.find_table::<acpi::madt::Madt>().ok()?;
 
     // According to ACPI spec [1], "If this bit [the Enabled bit] is set the processor is ready for

--- a/ostd/src/arch/x86/device/cmos.rs
+++ b/ostd/src/arch/x86/device/cmos.rs
@@ -26,7 +26,7 @@ sensitive_io_port!(unsafe {
 
 /// Gets the century register location. This function is used in RTC(Real Time Clock) module initialization.
 pub fn century_register() -> Option<u8> {
-    let acpi_tables = get_acpi_tables()?;
+    let acpi_tables = unsafe { get_acpi_tables()? };
     match acpi_tables.find_table::<Fadt>() {
         Ok(a) => Some(a.century),
         Err(er) => None,

--- a/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
@@ -86,6 +86,7 @@ pub fn init() {
     // Directed I/O (Revision 5.0), 3.16 Handling Requests to Reserved System Memory.
     let page_table = PageTable::<IommuPtConfig>::empty();
     for table in PciDeviceLocation::all() {
+        #[safety_macro::discharges(Memo(Uncoppied))]
         root_table.specify_device_page_table(table, unsafe { page_table.shallow_copy() })
     }
     PAGE_TABLE.call_once(|| SpinLock::new(root_table));

--- a/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
+++ b/ostd/src/arch/x86/iommu/dma_remapping/mod.rs
@@ -86,7 +86,7 @@ pub fn init() {
     // Directed I/O (Revision 5.0), 3.16 Handling Requests to Reserved System Memory.
     let page_table = PageTable::<IommuPtConfig>::empty();
     for table in PciDeviceLocation::all() {
-        #[safety_macro::discharges(Memo(Uncoppied))]
+        #[safety::discharges(Memo(Uncoppied))]
         root_table.specify_device_page_table(table, unsafe { page_table.shallow_copy() })
     }
     PAGE_TABLE.call_once(|| SpinLock::new(root_table));

--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -242,7 +242,8 @@ pub(super) unsafe fn init(base_register_vaddr: NonNull<u8>) {
         .call_once(|| SpinLock::new(unsafe { FaultEventRegisters::new(base_register_vaddr) }));
 }
 
-#[concur::ctxt(irq)]
+// #[concur::ctxt(irq)]
+#[safety_macro::Memo(Irq)]
 fn iommu_fault_handler(_frame: &TrapFrame) {
     let mut fault_event_regs = FAULT_EVENT_REGS.get().unwrap().lock();
 

--- a/ostd/src/arch/x86/iommu/fault.rs
+++ b/ostd/src/arch/x86/iommu/fault.rs
@@ -243,7 +243,7 @@ pub(super) unsafe fn init(base_register_vaddr: NonNull<u8>) {
 }
 
 // #[concur::ctxt(irq)]
-#[safety_macro::Memo(Irq)]
+#[safety::Memo(Irq)]
 fn iommu_fault_handler(_frame: &TrapFrame) {
     let mut fault_event_regs = FAULT_EVENT_REGS.get().unwrap().lock();
 

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -53,7 +53,7 @@ impl IrqRemapping {
 // FIXME: Mark this as unsafe. See
 // <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
 // #[concur::irq(enable)]
-#[safety_macro::Memo(IrqEnable)]
+#[safety::Memo(IrqEnable)]
 pub(crate) fn enable_local() {
     x86_64::instructions::interrupts::enable();
     // When emulated with QEMU, interrupts may not be delivered if a STI instruction is immediately
@@ -71,7 +71,7 @@ pub(crate) fn enable_local() {
 // FIXME: Mark this as unsafe. See
 // <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
 // #[concur::irq(enable)]
-#[safety_macro::Memo(IrqEnable)]
+#[safety::Memo(IrqEnable)]
 pub(crate) fn enable_local_and_halt() {
     // SAFETY:
     // 1. `sti` is safe to use because its safety requirement is upheld by the caller.
@@ -88,7 +88,7 @@ pub(crate) fn enable_local_and_halt() {
 }
 
 // #[concur::irq(disable)]
-#[safety_macro::Memo(IrqDisable)]
+#[safety::Memo(IrqDisable)]
 pub(crate) fn disable_local() {
     x86_64::instructions::interrupts::disable();
 }

--- a/ostd/src/arch/x86/irq.rs
+++ b/ostd/src/arch/x86/irq.rs
@@ -52,7 +52,8 @@ impl IrqRemapping {
 
 // FIXME: Mark this as unsafe. See
 // <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
-#[concur::irq(enable)]
+// #[concur::irq(enable)]
+#[safety_macro::Memo(IrqEnable)]
 pub(crate) fn enable_local() {
     x86_64::instructions::interrupts::enable();
     // When emulated with QEMU, interrupts may not be delivered if a STI instruction is immediately
@@ -69,7 +70,8 @@ pub(crate) fn enable_local() {
 //
 // FIXME: Mark this as unsafe. See
 // <https://github.com/asterinas/asterinas/issues/1120#issuecomment-2748696592>.
-#[concur::irq(enable)]
+// #[concur::irq(enable)]
+#[safety_macro::Memo(IrqEnable)]
 pub(crate) fn enable_local_and_halt() {
     // SAFETY:
     // 1. `sti` is safe to use because its safety requirement is upheld by the caller.
@@ -85,7 +87,8 @@ pub(crate) fn enable_local_and_halt() {
     };
 }
 
-#[concur::irq(disable)]
+// #[concur::irq(disable)]
+#[safety_macro::Memo(IrqDisable)]
 pub(crate) fn disable_local() {
     x86_64::instructions::interrupts::disable();
 }

--- a/ostd/src/arch/x86/kernel/acpi/dmar.rs
+++ b/ostd/src/arch/x86/kernel/acpi/dmar.rs
@@ -74,7 +74,7 @@ unsafe impl AcpiTable for DmarHeader {
 impl Dmar {
     /// Creates a instance from ACPI table.
     pub fn new() -> Option<Self> {
-        let acpi_table = super::get_acpi_tables()?;
+        let acpi_table = unsafe { super::get_acpi_tables()? };
 
         let dmar_mapping = acpi_table.find_table::<DmarHeader>().ok()?;
 

--- a/ostd/src/arch/x86/kernel/irq/mod.rs
+++ b/ostd/src/arch/x86/kernel/irq/mod.rs
@@ -166,7 +166,7 @@ pub(in crate::arch) fn init(io_mem_builder: &IoMemAllocatorBuilder) {
     // the I/O APIC, we may need to find another way to determine the I/O APIC address
     // correctly and reliably (e.g., by parsing the MultiProcessor Specification, which has
     // been deprecated for a long time and may not even exist in modern hardware).
-    let acpi_tables = get_acpi_tables().unwrap();
+    let acpi_tables = unsafe { get_acpi_tables().unwrap() };
     let madt_table = acpi_tables.find_table::<Madt>().unwrap();
 
     // "A one indicates that the system also has a PC-AT-compatible dual-8259 setup. The 8259

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -101,7 +101,7 @@ pub fn determine_tsc_freq_via_pit() -> u64 {
     return FREQUENCY.load(Ordering::Acquire);
 
     // #[concur::ctxt(irq)]
-    #[safety_macro::Memo(Irq)]
+    #[safety::Memo(Irq)]
     fn pit_callback(trap_frame: &TrapFrame) {
         static IN_TIME: AtomicU64 = AtomicU64::new(0);
         static TSC_FIRST_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/ostd/src/arch/x86/kernel/tsc.rs
+++ b/ostd/src/arch/x86/kernel/tsc.rs
@@ -100,7 +100,8 @@ pub fn determine_tsc_freq_via_pit() -> u64 {
 
     return FREQUENCY.load(Ordering::Acquire);
 
-    #[concur::ctxt(irq)]
+    // #[concur::ctxt(irq)]
+    #[safety_macro::Memo(Irq)]
     fn pit_callback(trap_frame: &TrapFrame) {
         static IN_TIME: AtomicU64 = AtomicU64::new(0);
         static TSC_FIRST_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -59,7 +59,10 @@ pub unsafe fn unprotect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), Pag
             let vaddr = paddr_to_vaddr(gpa + i * PAGE_SIZE);
             // SAFETY: The caller ensures that the address range exists in the linear mapping and
             // can be mapped as shared pages.
-            unsafe { boot_pt.protect_base_page(vaddr, protect_op) };
+            #[safety_macro::discharges(Memo(ValidKernelMapping))]
+            unsafe {
+                boot_pt.protect_base_page(vaddr, protect_op)
+            };
         }
     });
 

--- a/ostd/src/arch/x86/tdx_guest.rs
+++ b/ostd/src/arch/x86/tdx_guest.rs
@@ -59,7 +59,7 @@ pub unsafe fn unprotect_gpa_range(gpa: Paddr, page_num: usize) -> Result<(), Pag
             let vaddr = paddr_to_vaddr(gpa + i * PAGE_SIZE);
             // SAFETY: The caller ensures that the address range exists in the linear mapping and
             // can be mapped as shared pages.
-            #[safety_macro::discharges(Memo(ValidKernelMapping))]
+            #[safety::discharges(Memo(ValidKernelMapping))]
             unsafe {
                 boot_pt.protect_base_page(vaddr, protect_op)
             };

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -137,7 +137,7 @@ fn init_periodic_mode_config() {
     drop(irq);
 
     // #[concur::ctxt(irq)]
-    #[safety_macro::Memo(Irq)]
+    #[safety::Memo(Irq)]
     fn pit_callback(_trap_frame: &TrapFrame) {
         static IN_TIME: AtomicU64 = AtomicU64::new(0);
         static APIC_FIRST_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/ostd/src/arch/x86/timer/apic.rs
+++ b/ostd/src/arch/x86/timer/apic.rs
@@ -136,7 +136,8 @@ fn init_periodic_mode_config() {
     // Disable PIT
     drop(irq);
 
-    #[concur::ctxt(irq)]
+    // #[concur::ctxt(irq)]
+    #[safety_macro::Memo(Irq)]
     fn pit_callback(_trap_frame: &TrapFrame) {
         static IN_TIME: AtomicU64 = AtomicU64::new(0);
         static APIC_FIRST_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/ostd/src/arch/x86/timer/hpet.rs
+++ b/ostd/src/arch/x86/timer/hpet.rs
@@ -133,7 +133,7 @@ impl Hpet {
 /// HPET init, need to init IOAPIC before init this function
 #[expect(dead_code)]
 pub fn init() -> Result<(), AcpiError> {
-    let tables = get_acpi_tables().unwrap();
+    let tables = unsafe { get_acpi_tables().unwrap() };
 
     let hpet_info = HpetInfo::new(&tables)?;
     assert_ne!(hpet_info.base_address, 0, "HPET address should not be zero");

--- a/ostd/src/arch/x86/timer/mod.rs
+++ b/ostd/src/arch/x86/timer/mod.rs
@@ -61,7 +61,8 @@ pub(super) fn init_ap() {
     }
 }
 
-#[concur::ctxt(irq)]
+// #[concur::ctxt(irq)]
+#[safety_macro::Memo(Irq)]
 fn timer_callback(_: &TrapFrame) {
     let irq_guard = trap::irq::disable_local();
     if irq_guard.current_cpu() == CpuId::bsp() {

--- a/ostd/src/arch/x86/timer/mod.rs
+++ b/ostd/src/arch/x86/timer/mod.rs
@@ -62,7 +62,7 @@ pub(super) fn init_ap() {
 }
 
 // #[concur::ctxt(irq)]
-#[safety_macro::Memo(Irq)]
+#[safety::Memo(Irq)]
 fn timer_callback(_: &TrapFrame) {
     let irq_guard = trap::irq::disable_local();
     if irq_guard.current_cpu() == CpuId::bsp() {

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -148,7 +148,7 @@ pub fn is_kernel_interrupted() -> bool {
 /// Handle traps (only from kernel).
 #[no_mangle]
 // #[concur::ctxt(irq)]
-#[safety_macro::Memo(Irq)]
+#[safety::Memo(Irq)]
 extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
     fn enable_local_if(cond: bool) {
         if cond {

--- a/ostd/src/arch/x86/trap/mod.rs
+++ b/ostd/src/arch/x86/trap/mod.rs
@@ -147,7 +147,8 @@ pub fn is_kernel_interrupted() -> bool {
 
 /// Handle traps (only from kernel).
 #[no_mangle]
-#[concur::ctxt(irq)]
+// #[concur::ctxt(irq)]
+#[safety_macro::Memo(Irq)]
 extern "sysv64" fn trap_handler(f: &mut TrapFrame) {
     fn enable_local_if(cond: bool) {
         if cond {

--- a/ostd/src/cpu/local/mod.rs
+++ b/ostd/src/cpu/local/mod.rs
@@ -192,13 +192,13 @@ static CPU_LOCAL_STORAGES: Once<&'static [Paddr]> = Once::new();
 /// # Safety
 ///
 /// 1. This function must be called in the boot context of the BSP, at a time
-/// when the APs have not yet booted.
+///    when the APs have not yet booted.
 /// 2. The CPU-local data on the BSP must not be used before calling this
-/// function to copy it for the APs. Otherwise, the copied data will
-/// contain non-constant (also non-`Copy`) data, resulting in undefined
-/// behavior when it's loaded on the APs.
+///    function to copy it for the APs. Otherwise, the copied data will
+///    contain non-constant (also non-`Copy`) data, resulting in undefined
+///    behavior when it's loaded on the APs.
 /// 3. The caller must ensure that the `num_cpus` matches the number of all
-/// CPUs that will access the CPU-local storage.
+///    CPUs that will access the CPU-local storage.
 pub(crate) unsafe fn copy_bsp_for_ap(num_cpus: usize) {
     let num_aps = num_cpus - 1; // BSP does not need allocated storage.
     if num_aps == 0 {

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -20,6 +20,8 @@
 #![feature(sync_unsafe_cell)]
 #![feature(trait_upcasting)]
 #![feature(unbounded_shifts)]
+#![feature(stmt_expr_attributes)]
+#![feature(proc_macro_hygiene)]
 #![expect(internal_features)]
 #![no_std]
 #![warn(missing_docs)]

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -20,11 +20,12 @@
 #![feature(sync_unsafe_cell)]
 #![feature(trait_upcasting)]
 #![feature(unbounded_shifts)]
-#![feature(stmt_expr_attributes)]
-#![feature(proc_macro_hygiene)]
 #![expect(internal_features)]
 #![no_std]
 #![warn(missing_docs)]
+// Required by tag-std / rapx
+#![feature(stmt_expr_attributes, proc_macro_hygiene, register_tool)]
+#![register_tool(rapx)]
 
 extern crate alloc;
 

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -198,8 +198,8 @@ pub(super) fn get_global_frame_allocator() -> &'static dyn GlobalFrameAllocator 
 /// 1. This function should be called only once.
 /// 2. Memory regions should be initialized.
 /// 3. Early allocator should be initialized.
-#[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
-#[safety_macro::Memo(
+#[safety::Memo(CallOnce, memo = "global::CallOnce")]
+#[safety::Memo(
     Initialized,
     memo = "precond::Initialized(EARLY_INFO.memory_regions) && precond::Initialized(EARLY_ALLOCATOR)"
 )]
@@ -366,8 +366,8 @@ pub(crate) fn early_alloc(layout: Layout) -> Option<Paddr> {
 ///
 /// 1. This function should be called only once.
 /// 2. Memory regions should be ready.
-#[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
-#[safety_macro::Memo(Initialized, memo = "precond::Initialized(EARLY_INFO.memory_regions)")]
+#[safety::Memo(CallOnce, memo = "global::CallOnce")]
+#[safety::Memo(Initialized, memo = "precond::Initialized(EARLY_INFO.memory_regions)")]
 // #[safety::global::CallOnce]
 // #[safety::precond::Initialized(EARLY_INFO.memory_regions)]
 pub(crate) unsafe fn init_early_allocator() {

--- a/ostd/src/mm/frame/allocator.rs
+++ b/ostd/src/mm/frame/allocator.rs
@@ -198,9 +198,14 @@ pub(super) fn get_global_frame_allocator() -> &'static dyn GlobalFrameAllocator 
 /// 1. This function should be called only once.
 /// 2. Memory regions should be initialized.
 /// 3. Early allocator should be initialized.
-#[safety::global::CallOnce]
-#[safety::precond::Initialized(EARLY_INFO.memory_regions)]
-#[safety::precond::Initialized(EARLY_ALLOCATOR)]
+#[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+#[safety_macro::Memo(
+    Initialized,
+    memo = "precond::Initialized(EARLY_INFO.memory_regions) && precond::Initialized(EARLY_ALLOCATOR)"
+)]
+// #[safety::global::CallOnce]
+// #[safety::precond::Initialized(EARLY_INFO.memory_regions)]
+// #[safety::precond::Initialized(EARLY_ALLOCATOR)]
 pub(crate) unsafe fn init() {
     let regions = &crate::boot::EARLY_INFO.get().unwrap().memory_regions;
 
@@ -358,11 +363,13 @@ pub(crate) fn early_alloc(layout: Layout) -> Option<Paddr> {
 /// early allocator.
 ///
 /// # Safety
-/// 
+///
 /// 1. This function should be called only once.
 /// 2. Memory regions should be ready.
-#[safety::global::CallOnce]
-#[safety::precond::Initialized(EARLY_INFO.memory_regions)]
+#[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+#[safety_macro::Memo(Initialized, memo = "precond::Initialized(EARLY_INFO.memory_regions)")]
+// #[safety::global::CallOnce]
+// #[safety::precond::Initialized(EARLY_INFO.memory_regions)]
 pub(crate) unsafe fn init_early_allocator() {
     let mut early_allocator = EARLY_ALLOCATOR.lock();
     *early_allocator = Some(EarlyFrameAllocator::new());

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -305,7 +305,7 @@ impl MetaSlot {
     /// # Safety
     ///
     /// The caller must have already held a reference to the frame.
-    #[safety_macro::Memo(SlotFrameRefHeld, memo = "precond::SlotFrameRefHeld(self)")]
+    #[safety::Memo(SlotFrameRefHeld, memo = "precond::SlotFrameRefHeld(self)")]
     // #[safety::precond::SlotFrameRefHeld(self)]
     pub(super) unsafe fn inc_ref_count(&self) {
         let last_ref_cnt = self.ref_count.fetch_add(1, Ordering::Relaxed);
@@ -333,11 +333,11 @@ impl MetaSlot {
     ///
     /// The returned pointer should not be dereferenced as mutable unless having
     /// exclusive access to the metadata slot.
-    #[safety_macro::Memo(
+    #[safety::Memo(
         PostToFunc,
         memo = "precond::PostToFunc(NULL, MetaSlot::write_meta, self, *)"
     )]
-    #[safety_macro::Memo(MutExclusive, memo = "postcond::MutExclusive(ReturnValue)")]
+    #[safety::Memo(MutExclusive, memo = "postcond::MutExclusive(ReturnValue)")]
     // #[safety::precond::PostToFunc(NULL, MetaSlot::write_meta, self, *)]
     // #[safety::postcond::MutExclusive(ReturnValue)]
     pub(super) unsafe fn dyn_meta_ptr(&self) -> *mut dyn AnyFrameMeta {
@@ -363,11 +363,11 @@ impl MetaSlot {
     ///  - the initialized metadata is of type `M`;
     ///  - the returned pointer should not be dereferenced as mutable unless
     ///    having exclusive access to the metadata slot.
-    #[safety_macro::Memo(
+    #[safety::Memo(
         PriorToFunc,
         memo = "postcond::PriorToFunc(MetaSlot::write_meta, ReturnValue, Instance(M))"
     )]
-    #[safety_macro::Memo(MutExclusive, memo = "postcond::MutExclusive(ReturnValue)")]
+    #[safety::Memo(MutExclusive, memo = "postcond::MutExclusive(ReturnValue)")]
     // #[safety::postcond::PriorToFunc(MetaSlot::write_meta, ReturnValue, Instance(M))]
     // #[safety::postcond::MutExclusive(ReturnValue)]
     pub(super) fn as_meta_ptr<M: AnyFrameMeta>(&self) -> *mut M {
@@ -379,7 +379,7 @@ impl MetaSlot {
     /// # Safety
     ///
     /// The caller should have exclusive access to the metadata slot's fields.
-    #[safety_macro::Memo(MutExclusive, memo = "global::MutExclusive(self)")]
+    #[safety::Memo(MutExclusive, memo = "global::MutExclusive(self)")]
     // #[safety::global::MutExclusive(self)]
     pub(super) unsafe fn write_meta<M: AnyFrameMeta>(&self, metadata: M) {
         const { assert!(size_of::<M>() <= FRAME_METADATA_MAX_SIZE) };
@@ -405,8 +405,8 @@ impl MetaSlot {
     /// The caller should ensure that:
     ///  - the reference count is `0` (so we are the sole owner of the frame);
     ///  - the metadata is initialized;
-    #[safety_macro::Memo(Equal, memo = "precond::Equal(self.ref_count, 0)")]
-    #[safety_macro::Memo(Initialized, memo = "precond::Initialized(self.storage)")]
+    #[safety::Memo(Equal, memo = "precond::Equal(self.ref_count, 0)")]
+    #[safety::Memo(Initialized, memo = "precond::Initialized(self.storage)")]
     // #[safety::precond::Equal(self.ref_count, 0)]
     // #[safety::precond::Initialized(self.storage)]
     pub(super) unsafe fn drop_last_in_place(&self) {
@@ -432,8 +432,8 @@ impl MetaSlot {
     ///  - the reference count is `0` (so we are the sole owner of the frame);
     ///  - the metadata is initialized;
     ///
-    #[safety_macro::Memo(Equal, memo = "precond::Equal(self.ref_count, 0)")]
-    #[safety_macro::Memo(Initialized, memo = "precond::Initialized(self.storage)")]
+    #[safety::Memo(Equal, memo = "precond::Equal(self.ref_count, 0)")]
+    #[safety::Memo(Initialized, memo = "precond::Initialized(self.storage)")]
     // #[safety::precond::Equal(self.ref_count, 0)]
     // #[safety::precond::Initialized(self.storage)]
     pub(super) unsafe fn drop_meta_in_place(&self) {
@@ -478,8 +478,8 @@ impl_frame_meta_for!(MetaPageMeta);
 ///
 /// 1. This function should be called only once.
 /// 2. This function should be called only on the BSP and before any APs are started.
-#[safety_macro::Memo(BSP_BUT_AP, memo = "global::Context(BSP_BUT_AP)")]
-#[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+#[safety::Memo(BSP_BUT_AP, memo = "global::Context(BSP_BUT_AP)")]
+#[safety::Memo(CallOnce, memo = "global::CallOnce")]
 // #[safety::global::CallOnce]
 // #[safety::global::Context(BSP_BUT_AP)] //todo:: need definition of BSP_BUT_AP
 pub(crate) unsafe fn init() -> Segment<MetaPageMeta> {

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -211,8 +211,10 @@ impl<M: AnyFrameMeta + ?Sized> Frame<M> {
     ///
     /// Also, the caller ensures that the usage of the frame is correct. There's
     /// no checking of the usage in this function.
-    #[safety::precond::FrameForgotten(paddr)]
-    #[safety::global::TaggedCallOnce(paddr)]
+    #[safety_macro::Memo(FrameForgotten, memo = "precond::FrameForgotten(paddr)")]
+    #[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(paddr)")]
+    // #[safety::precond::FrameForgotten(paddr)]
+    // #[safety::global::TaggedCallOnce(paddr)]
     pub(in crate::mm) unsafe fn from_raw(paddr: Paddr) -> Self {
         debug_assert!(paddr < max_paddr());
 
@@ -324,8 +326,10 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
 /// The caller should ensure the following conditions:
 ///  1. The physical address must represent a valid frame;
 ///  2. The caller must have already held a reference to the frame.
-#[safety::precond::ValidFrame(paddr)]
-#[safety::precond::FrameRefHeld(paddr)]
+#[safety_macro::Memo(ValidFrame, memo = "precond::ValidFrame(paddr)")]
+#[safety_macro::Memo(FrameRefHeld, memo = "precond::FrameRefHeld(paddr)")]
+// #[safety::precond::ValidFrame(paddr)]
+// #[safety::precond::FrameRefHeld(paddr)]
 pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
     debug_assert!(paddr % PAGE_SIZE == 0);
     debug_assert!(paddr < max_paddr());

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -211,8 +211,8 @@ impl<M: AnyFrameMeta + ?Sized> Frame<M> {
     ///
     /// Also, the caller ensures that the usage of the frame is correct. There's
     /// no checking of the usage in this function.
-    #[safety_macro::Memo(FrameForgotten, memo = "precond::FrameForgotten(paddr)")]
-    #[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(paddr)")]
+    #[safety::Memo(FrameForgotten, memo = "precond::FrameForgotten(paddr)")]
+    #[safety::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(paddr)")]
     // #[safety::precond::FrameForgotten(paddr)]
     // #[safety::global::TaggedCallOnce(paddr)]
     pub(in crate::mm) unsafe fn from_raw(paddr: Paddr) -> Self {
@@ -326,8 +326,8 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
 /// The caller should ensure the following conditions:
 ///  1. The physical address must represent a valid frame;
 ///  2. The caller must have already held a reference to the frame.
-#[safety_macro::Memo(ValidFrame, memo = "precond::ValidFrame(paddr)")]
-#[safety_macro::Memo(FrameRefHeld, memo = "precond::FrameRefHeld(paddr)")]
+#[safety::Memo(ValidFrame, memo = "precond::ValidFrame(paddr)")]
+#[safety::Memo(FrameRefHeld, memo = "precond::FrameRefHeld(paddr)")]
 // #[safety::precond::ValidFrame(paddr)]
 // #[safety::precond::FrameRefHeld(paddr)]
 pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -115,7 +115,8 @@ impl<M: AnyFrameMeta> Segment<M> {
     /// The range must be a forgotten [`Segment`] that matches the type `M`.
     /// It could be manually forgotten by [`core::mem::forget`],
     /// [`ManuallyDrop`], or [`Self::into_raw`].
-    #[safety::precond::RangeSegmentForgotten(range)]
+    #[safety_macro::Memo(RangeSegmentForgotten, memo = "precond::RangeSegmentForgotten(range)")]
+    // #[safety::precond::RangeSegmentForgotten(range)]
     pub(crate) unsafe fn from_raw(range: Range<Paddr>) -> Self {
         debug_assert_eq!(range.start % PAGE_SIZE, 0);
         debug_assert_eq!(range.end % PAGE_SIZE, 0);

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -115,7 +115,7 @@ impl<M: AnyFrameMeta> Segment<M> {
     /// The range must be a forgotten [`Segment`] that matches the type `M`.
     /// It could be manually forgotten by [`core::mem::forget`],
     /// [`ManuallyDrop`], or [`Self::into_raw`].
-    #[safety_macro::Memo(RangeSegmentForgotten, memo = "precond::RangeSegmentForgotten(range)")]
+    #[safety::Memo(RangeSegmentForgotten, memo = "precond::RangeSegmentForgotten(range)")]
     // #[safety::precond::RangeSegmentForgotten(range)]
     pub(crate) unsafe fn from_raw(range: Range<Paddr>) -> Self {
         debug_assert_eq!(range.start % PAGE_SIZE, 0);

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -136,7 +136,7 @@ impl<M: AnyFrameMeta + ?Sized> UniqueFrame<M> {
     ///
     /// The caller must ensure that the physical address is valid and points to
     /// a forgotten frame that was previously casted by [`Self::into_raw`].
-    #[safety_macro::Memo(FrameForgotten, memo = "precond::FrameForgotten(paddr)")]
+    #[safety::Memo(FrameForgotten, memo = "precond::FrameForgotten(paddr)")]
     // #[safety::precond::FrameForgotten(paddr)]
     pub(crate) unsafe fn from_raw(paddr: Paddr) -> Self {
         let vaddr = mapping::frame_to_meta::<PagingConsts>(paddr);

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -136,7 +136,8 @@ impl<M: AnyFrameMeta + ?Sized> UniqueFrame<M> {
     ///
     /// The caller must ensure that the physical address is valid and points to
     /// a forgotten frame that was previously casted by [`Self::into_raw`].
-    #[safety::precond::FrameForgotten(paddr)]
+    #[safety_macro::Memo(FrameForgotten, memo = "precond::FrameForgotten(paddr)")]
+    // #[safety::precond::FrameForgotten(paddr)]
     pub(crate) unsafe fn from_raw(paddr: Paddr) -> Self {
         let vaddr = mapping::frame_to_meta::<PagingConsts>(paddr);
         let ptr = vaddr as *const MetaSlot;

--- a/ostd/src/mm/heap/slot.rs
+++ b/ostd/src/mm/heap/slot.rs
@@ -66,7 +66,7 @@ impl HeapSlot {
     ///
     /// If the pointer is from a [`super::Slab`] or [`Segment`], the slot must
     /// have a size that matches the slot size of the slab or segment respectively.
-    #[safety_macro::Memo(ValidSlot, memo = "precond::ValidSlot(addr)")]
+    #[safety::Memo(ValidSlot, memo = "precond::ValidSlot(addr)")]
     // #[safety::precond::ValidSlot(addr)]
     pub(super) unsafe fn new(addr: NonNull<u8>, info: SlotInfo) -> Self {
         Self { addr, info }

--- a/ostd/src/mm/heap/slot.rs
+++ b/ostd/src/mm/heap/slot.rs
@@ -66,7 +66,8 @@ impl HeapSlot {
     ///
     /// If the pointer is from a [`super::Slab`] or [`Segment`], the slot must
     /// have a size that matches the slot size of the slab or segment respectively.
-    #[safety::precond::ValidSlot(addr)]
+    #[safety_macro::Memo(ValidSlot, memo = "precond::ValidSlot(addr)")]
+    // #[safety::precond::ValidSlot(addr)]
     pub(super) unsafe fn new(addr: NonNull<u8>, info: SlotInfo) -> Self {
         Self { addr, info }
     }

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -292,8 +292,8 @@ pub enum Infallible {}
 ///
 /// [valid]: crate::mm::io#safety
 
-#[safety_macro::Memo(ReadLen, memo = "precond::ReadLen(src, len)")]
-#[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+#[safety::Memo(ReadLen, memo = "precond::ReadLen(src, len)")]
+#[safety::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
 // #[safety::precond::ReadLen(src, len)]
 // #[safety::precond::WriteLen(dst, len)]
 unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
@@ -328,8 +328,8 @@ unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
 /// - `dst` must either be [valid] for writes of `len` bytes or be in user space for `len` bytes.
 ///
 /// [valid]: crate::mm::io#safety
-#[safety_macro::Memo(ReadLen, memo = "precond::ReadLen(src, len)")]
-#[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+#[safety::Memo(ReadLen, memo = "precond::ReadLen(src, len)")]
+#[safety::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
 // #[safety::precond::ReadLen(src, len)]
 // #[safety::precond::ValidWriteLen(dst, len)]
 unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, len: usize) -> usize {
@@ -348,7 +348,7 @@ unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, len: usize) -> usize {
 /// - `dst` must either be [valid] for writes of `len` bytes or be in user space for `len` bytes.
 ///
 /// [valid]: crate::mm::io#safety
-#[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+#[safety::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
 // #[safety::precond::ValidWriteLen(dst, len)] //or
 // #[safety::precond::UserSpaceLen(dst, len)]
 unsafe fn memset_fallible(dst: *mut u8, value: u8, len: usize) -> usize {
@@ -482,7 +482,7 @@ impl<'a> VmReader<'a, Infallible> {
     /// `ptr` must be [valid] for reads of `len` bytes during the entire lifetime `a`.
     ///
     /// [valid]: crate::mm::io#safety
-    #[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+    #[safety::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
     // #[safety::precond::UserSpaceLen(dst, len)]
     pub unsafe fn from_kernel_space(ptr: *const u8, len: usize) -> Self {
         // Rust is allowed to give the reference to a zero-sized object a very small address,
@@ -583,7 +583,7 @@ impl VmReader<'_, Fallible> {
     /// # Safety
     ///
     /// The virtual address range `ptr..ptr + len` must be in user space.
-    #[safety_macro::Memo(UserSpaceLen, memo = "precond::UserSpaceLen(ptr, len)")]
+    #[safety::Memo(UserSpaceLen, memo = "precond::UserSpaceLen(ptr, len)")]
     // #[safety::precond::UserSpaceLen(ptr, len)]
     pub unsafe fn from_user_space(ptr: *const u8, len: usize) -> Self {
         debug_assert!(ptr.addr().checked_add(len).unwrap() <= MAX_USERSPACE_VADDR);
@@ -727,7 +727,7 @@ impl<'a> VmWriter<'a, Infallible> {
     /// `ptr` must be [valid] for writes of `len` bytes during the entire lifetime `a`.
     ///
     /// [valid]: crate::mm::io#safety
-    #[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+    #[safety::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
     // #[safety::precond::ValidWriteLen(ptr, len)]
     pub unsafe fn from_kernel_space(ptr: *mut u8, len: usize) -> Self {
         // If casting a zero sized slice to a pointer, the pointer may be null
@@ -844,7 +844,7 @@ impl VmWriter<'_, Fallible> {
     /// # Safety
     ///
     /// `ptr` must be in user space for `len` bytes.
-    #[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+    #[safety::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
     // #[safety::precond::UserSpaceLen(ptr, len)]
     pub unsafe fn from_user_space(ptr: *mut u8, len: usize) -> Self {
         debug_assert!(ptr.addr().checked_add(len).unwrap() <= MAX_USERSPACE_VADDR);

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -291,8 +291,11 @@ pub enum Infallible {}
 /// - `dst` must be [valid] for writes of `len` bytes.
 ///
 /// [valid]: crate::mm::io#safety
-#[safety::precond::ReadLen(src, len)]
-#[safety::precond::WriteLen(dst, len)]
+
+#[safety_macro::Memo(ReadLen, memo = "precond::ReadLen(src, len)")]
+#[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+// #[safety::precond::ReadLen(src, len)]
+// #[safety::precond::WriteLen(dst, len)]
 unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
     // This method is implemented by calling `volatile_copy_memory`. Note that even with the
     // "volatile" keyword, data races are still considered undefined behavior (UB) in both the Rust
@@ -325,8 +328,10 @@ unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {
 /// - `dst` must either be [valid] for writes of `len` bytes or be in user space for `len` bytes.
 ///
 /// [valid]: crate::mm::io#safety
-#[safety::precond::ReadLen(src, len)]
-#[safety::precond::ValidWriteLen(dst, len)]
+#[safety_macro::Memo(ReadLen, memo = "precond::ReadLen(src, len)")]
+#[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+// #[safety::precond::ReadLen(src, len)]
+// #[safety::precond::ValidWriteLen(dst, len)]
 unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, len: usize) -> usize {
     // SAFETY: The safety is upheld by the caller.
     let failed_bytes = unsafe { __memcpy_fallible(dst, src, len) };
@@ -343,8 +348,9 @@ unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, len: usize) -> usize {
 /// - `dst` must either be [valid] for writes of `len` bytes or be in user space for `len` bytes.
 ///
 /// [valid]: crate::mm::io#safety
-#[safety::precond::ValidWriteLen(dst, len)] //or
-#[safety::precond::UserSpaceLen(dst, len)]
+#[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+// #[safety::precond::ValidWriteLen(dst, len)] //or
+// #[safety::precond::UserSpaceLen(dst, len)]
 unsafe fn memset_fallible(dst: *mut u8, value: u8, len: usize) -> usize {
     // SAFETY: The safety is upheld by the caller.
     let failed_bytes = unsafe { __memset_fallible(dst, value, len) };
@@ -476,7 +482,8 @@ impl<'a> VmReader<'a, Infallible> {
     /// `ptr` must be [valid] for reads of `len` bytes during the entire lifetime `a`.
     ///
     /// [valid]: crate::mm::io#safety
-    #[safety::precond::UserSpaceLen(dst, len)]
+    #[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+    // #[safety::precond::UserSpaceLen(dst, len)]
     pub unsafe fn from_kernel_space(ptr: *const u8, len: usize) -> Self {
         // Rust is allowed to give the reference to a zero-sized object a very small address,
         // falling out of the kernel virtual address space range.
@@ -576,7 +583,8 @@ impl VmReader<'_, Fallible> {
     /// # Safety
     ///
     /// The virtual address range `ptr..ptr + len` must be in user space.
-    #[safety::precond::UserSpaceLen(ptr, len)]
+    #[safety_macro::Memo(UserSpaceLen, memo = "precond::UserSpaceLen(ptr, len)")]
+    // #[safety::precond::UserSpaceLen(ptr, len)]
     pub unsafe fn from_user_space(ptr: *const u8, len: usize) -> Self {
         debug_assert!(ptr.addr().checked_add(len).unwrap() <= MAX_USERSPACE_VADDR);
 
@@ -719,7 +727,8 @@ impl<'a> VmWriter<'a, Infallible> {
     /// `ptr` must be [valid] for writes of `len` bytes during the entire lifetime `a`.
     ///
     /// [valid]: crate::mm::io#safety
-    #[safety::precond::ValidWriteLen(ptr, len)]
+    #[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+    // #[safety::precond::ValidWriteLen(ptr, len)]
     pub unsafe fn from_kernel_space(ptr: *mut u8, len: usize) -> Self {
         // If casting a zero sized slice to a pointer, the pointer may be null
         // and does not reside in our kernel space range.
@@ -835,7 +844,8 @@ impl VmWriter<'_, Fallible> {
     /// # Safety
     ///
     /// `ptr` must be in user space for `len` bytes.
-    #[safety::precond::UserSpaceLen(ptr, len)]
+    #[safety_macro::Memo(WriteLen, memo = "precond::WriteLen(dst, len)")]
+    // #[safety::precond::UserSpaceLen(ptr, len)]
     pub unsafe fn from_user_space(ptr: *mut u8, len: usize) -> Self {
         debug_assert!(ptr.addr().checked_add(len).unwrap() <= MAX_USERSPACE_VADDR);
 

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -125,11 +125,17 @@ impl KVirtArea {
     ///  - the map offset plus the length of the physical range exceeds the
     ///    area size;
     ///  - the provided physical range contains tracked physical addresses.
-    #[safety::precond::Align(area_size, PAGE_SIZE)]
-    #[safety::precond::Align(map_offset, PAGE_SIZE)]
-    #[safety::precond::Align(pa_range, PAGE_SIZE)]
-    #[safety::precond::Le(map_offset + pa_range.len(), area_size)]
-    #[safety::precond::FrameUntracked(pa_range)]
+    #[safety_macro::Memo(
+        Align,
+        memo = "precond::Align(area_size, PAGE_SIZE) && precond::Align(map_offset, PAGE_SIZE) && precond::Align(pa_range, PAGE_SIZE)"
+    )]
+    #[safety_macro::Memo(Le, memo = "precond::Le(map_offset + pa_range.len(), area_size)")]
+    #[safety_macro::Memo(FrameUntracked, memo = "precond::FrameUntracked(pa_range)")]
+    // #[safety::precond::Align(area_size, PAGE_SIZE)]
+    // #[safety::precond::Align(map_offset, PAGE_SIZE)]
+    // #[safety::precond::Align(pa_range, PAGE_SIZE)]
+    // #[safety::precond::Le(map_offset + pa_range.len(), area_size)]
+    // #[safety::precond::FrameUntracked(pa_range)]
     pub unsafe fn map_untracked_frames(
         area_size: usize,
         map_offset: usize,

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -125,12 +125,12 @@ impl KVirtArea {
     ///  - the map offset plus the length of the physical range exceeds the
     ///    area size;
     ///  - the provided physical range contains tracked physical addresses.
-    #[safety_macro::Memo(
+    #[safety::Memo(
         Align,
         memo = "precond::Align(area_size, PAGE_SIZE) && precond::Align(map_offset, PAGE_SIZE) && precond::Align(pa_range, PAGE_SIZE)"
     )]
-    #[safety_macro::Memo(Le, memo = "precond::Le(map_offset + pa_range.len(), area_size)")]
-    #[safety_macro::Memo(FrameUntracked, memo = "precond::FrameUntracked(pa_range)")]
+    #[safety::Memo(Le, memo = "precond::Le(map_offset + pa_range.len(), area_size)")]
+    #[safety::Memo(FrameUntracked, memo = "precond::FrameUntracked(pa_range)")]
     // #[safety::precond::Align(area_size, PAGE_SIZE)]
     // #[safety::precond::Align(map_offset, PAGE_SIZE)]
     // #[safety::precond::Align(pa_range, PAGE_SIZE)]

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -244,7 +244,8 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
 /// # Safety
 ///
 /// This function should only be called once per CPU.
-#[safety::global::TaggedCallOnce(CPU_ID)]
+#[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(CPU_ID)")]
+// #[safety::global::TaggedCallOnce(CPU_ID)]
 pub unsafe fn activate_kernel_page_table() {
     let kpt = KERNEL_PAGE_TABLE
         .get()

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -244,7 +244,7 @@ pub fn init_kernel_page_table(meta_pages: Segment<MetaPageMeta>) {
 /// # Safety
 ///
 /// This function should only be called once per CPU.
-#[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(CPU_ID)")]
+#[safety::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(CPU_ID)")]
 // #[safety::global::TaggedCallOnce(CPU_ID)]
 pub unsafe fn activate_kernel_page_table() {
     let kpt = KERNEL_PAGE_TABLE

--- a/ostd/src/mm/page_table/boot_pt.rs
+++ b/ostd/src/mm/page_table/boot_pt.rs
@@ -70,10 +70,10 @@ where
 ///  - no [`with_borrow`] calls are performed on this CPU after this dismissal;
 ///  - no [`with_borrow`] calls are performed on this CPU after the activation
 ///    of another page table and before this dismissal.
-#[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(CPU_ID)")]
-#[safety_macro::Memo(NonBootPTActivated, memo = "precond::NonBootPTActivated")]
-#[safety_macro::Memo(NotPostToFunc, memo = "precond::NotPostToFunc(with_borrow)")]
-#[safety_macro::Memo(NotPriorToFunc, memo = "postcond::NotPriorToFunc(with_borrow)")]
+#[safety::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(CPU_ID)")]
+#[safety::Memo(NonBootPTActivated, memo = "precond::NonBootPTActivated")]
+#[safety::Memo(NotPostToFunc, memo = "precond::NotPostToFunc(with_borrow)")]
+#[safety::Memo(NotPriorToFunc, memo = "postcond::NotPriorToFunc(with_borrow)")]
 // #[safety::global::TaggedCallOnce(CPU_ID)]
 // #[safety::precond::NonBootPTActivated]
 // #[safety::precond::NotPostToFunc(with_borrow)]
@@ -140,8 +140,8 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
     /// This function should be called only once in the initialization phase.
     /// Otherwise, It would lead to double-drop of the page table frames set up
     /// by the firmware, loader or the setup code.
-    #[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
-    #[safety_macro::Memo(PAGETABLE_INITIALIZE, memo = "global::Context(PAGETABLE_INITIALIZE)")]
+    #[safety::Memo(CallOnce, memo = "global::CallOnce")]
+    #[safety::Memo(PAGETABLE_INITIALIZE, memo = "global::Context(PAGETABLE_INITIALIZE)")]
     // #[safety::global::CallOnce]
     // #[safety::global::Context(PAGETABLE_INITIALIZE)]
     unsafe fn from_current_pt() -> Self {
@@ -173,7 +173,7 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
     ///
     /// This function is unsafe because it can cause undefined behavior if the caller
     /// maps a page in the kernel address space.
-    #[safety_macro::Memo(ValidKernelMapping, memo = "precond::ValidKernelMapping(from)")]
+    #[safety::Memo(ValidKernelMapping, memo = "precond::ValidKernelMapping(from)")]
     // #[safety::precond::ValidKernelMapping(from)]
     pub unsafe fn map_base_page(&mut self, from: Vaddr, to: FrameNumber, prop: PageProperty) {
         let mut pt = self.root_pt;
@@ -217,7 +217,7 @@ impl<E: PageTableEntryTrait, C: PagingConstsTrait> BootPageTable<E, C> {
     ///
     /// This function is unsafe because it can cause undefined behavior if the caller
     /// maps a page in the kernel address space.
-    #[safety_macro::Memo(ValidKernelMapping, memo = "precond::ValidKernelMapping(virt_addr)")]
+    #[safety::Memo(ValidKernelMapping, memo = "precond::ValidKernelMapping(virt_addr)")]
     // #[safety::precond::ValidKernelMapping(virt_addr)]
     pub unsafe fn protect_base_page(
         &mut self,

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -205,8 +205,13 @@ fn dfs_acquire_lock<C: PageTableConfig>(
 ///
 /// The caller must ensure that the nodes in the specified sub-tree are locked
 /// and all guards are forgotten.
-#[safety::precond::SubtreeLocked(cur_node)]
-#[safety::precond::SubtreeGuardForgotten(cur_node)]
+#[safety_macro::Memo(SubtreeLocked, memo = "precond::SubtreeLocked(cur_node)")]
+// #[safety::precond::SubtreeLocked(cur_node)]
+#[safety_macro::Memo(
+    SubtreeGuardForgotten,
+    memo = "precond::SubtreeGuardForgotten(cur_node)"
+)]
+// #[safety::precond::SubtreeGuardForgotten(cur_node)]
 unsafe fn dfs_release_lock<'rcu, C: PageTableConfig>(
     guard: &'rcu dyn InAtomicMode,
     mut cur_node: PageTableGuard<'rcu, C>,
@@ -253,8 +258,13 @@ unsafe fn dfs_release_lock<'rcu, C: PageTableConfig>(
 ///
 /// This function must not be called upon a shared node, e.g., the second-
 /// top level nodes that the kernel space and user space share.
-#[safety::precond::SubtreeLocked(sub_tree)]
-#[safety::precond::SubtreeGuardForgotten(sub_tree)]
+#[safety_macro::Memo(SubtreeLocked, memo = "precond::SubtreeLocked(sub_tree)")]
+// #[safety::precond::SubtreeLocked(sub_tree)]
+#[safety_macro::Memo(
+    SubtreeGuardForgotten,
+    memo = "precond::SubtreeGuardForgotten(sub_tree)"
+)]
+// #[safety::precond::SubtreeGuardForgotten(sub_tree)]
 pub(super) unsafe fn dfs_mark_stray_and_unlock<C: PageTableConfig>(
     rcu_guard: &dyn InAtomicMode,
     mut sub_tree: PageTableGuard<C>,

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -205,9 +205,9 @@ fn dfs_acquire_lock<C: PageTableConfig>(
 ///
 /// The caller must ensure that the nodes in the specified sub-tree are locked
 /// and all guards are forgotten.
-#[safety_macro::Memo(SubtreeLocked, memo = "precond::SubtreeLocked(cur_node)")]
+#[safety::Memo(SubtreeLocked, memo = "precond::SubtreeLocked(cur_node)")]
 // #[safety::precond::SubtreeLocked(cur_node)]
-#[safety_macro::Memo(
+#[safety::Memo(
     SubtreeGuardForgotten,
     memo = "precond::SubtreeGuardForgotten(cur_node)"
 )]
@@ -258,9 +258,9 @@ unsafe fn dfs_release_lock<'rcu, C: PageTableConfig>(
 ///
 /// This function must not be called upon a shared node, e.g., the second-
 /// top level nodes that the kernel space and user space share.
-#[safety_macro::Memo(SubtreeLocked, memo = "precond::SubtreeLocked(sub_tree)")]
+#[safety::Memo(SubtreeLocked, memo = "precond::SubtreeLocked(sub_tree)")]
 // #[safety::precond::SubtreeLocked(sub_tree)]
-#[safety_macro::Memo(
+#[safety::Memo(
     SubtreeGuardForgotten,
     memo = "precond::SubtreeGuardForgotten(sub_tree)"
 )]

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -445,7 +445,7 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// The caller should ensure that
     ///  - the range being mapped does not affect kernel's memory safety;
     ///  - the physical address to be mapped is valid and safe to use;
-    
+
     pub unsafe fn map(&mut self, item: C::Item) -> Result<(), PageTableFrag<C>> {
         assert!(self.0.va < self.0.barrier_va.end);
         let (pa, level, prop) = C::item_into_raw(item);
@@ -521,8 +521,10 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// Panics if:
     ///  - the length is longer than the remaining range of the cursor;
     ///  - the length is not page-aligned.
-    #[safety::precond::Le(len, self.0.va_barrier.end - self.0.va)]
-    #[safety::precond::Align(len, C::BASE_PAGE_SIZE)]
+    #[safety_macro::Memo(Le, memo = "precond::Le(len, self.0.va_barrier.end - self.0.va)")]
+    // #[safety::precond::Le(len, self.0.va_barrier.end - self.0.va)]
+    #[safety_macro::Memo(Align, memo = "precond::Align(len, C::BASE_PAGE_SIZE)")]
+    // #[safety::precond::Align(len, C::BASE_PAGE_SIZE)]
     pub unsafe fn take_next(&mut self, len: usize) -> Option<PageTableFrag<C>> {
         self.0.find_next_impl(len, true, true)?;
 
@@ -559,8 +561,10 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// Panics if:
     ///  - the length is longer than the remaining range of the cursor;
     ///  - the length is not page-aligned.
-    #[safety::precond::Le(len, self.0.va_barrier.end - self.0.va)]
-    #[safety::precond::Align(len, C::BASE_PAGE_SIZE)]
+    #[safety_macro::Memo(Le, memo = "precond::Le(len, self.0.va_barrier.end - self.0.va)")]
+    // #[safety::precond::Le(len, self.0.va_barrier.end - self.0.va)]
+    #[safety_macro::Memo(Align, memo = "precond::Align(len, C::BASE_PAGE_SIZE)")]
+    // #[safety::precond::Align(len, C::BASE_PAGE_SIZE)]
     pub unsafe fn protect_next(
         &mut self,
         len: usize,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -521,9 +521,9 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// Panics if:
     ///  - the length is longer than the remaining range of the cursor;
     ///  - the length is not page-aligned.
-    #[safety_macro::Memo(Le, memo = "precond::Le(len, self.0.va_barrier.end - self.0.va)")]
+    #[safety::Memo(Le, memo = "precond::Le(len, self.0.va_barrier.end - self.0.va)")]
     // #[safety::precond::Le(len, self.0.va_barrier.end - self.0.va)]
-    #[safety_macro::Memo(Align, memo = "precond::Align(len, C::BASE_PAGE_SIZE)")]
+    #[safety::Memo(Align, memo = "precond::Align(len, C::BASE_PAGE_SIZE)")]
     // #[safety::precond::Align(len, C::BASE_PAGE_SIZE)]
     pub unsafe fn take_next(&mut self, len: usize) -> Option<PageTableFrag<C>> {
         self.0.find_next_impl(len, true, true)?;
@@ -561,9 +561,9 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// Panics if:
     ///  - the length is longer than the remaining range of the cursor;
     ///  - the length is not page-aligned.
-    #[safety_macro::Memo(Le, memo = "precond::Le(len, self.0.va_barrier.end - self.0.va)")]
+    #[safety::Memo(Le, memo = "precond::Le(len, self.0.va_barrier.end - self.0.va)")]
     // #[safety::precond::Le(len, self.0.va_barrier.end - self.0.va)]
-    #[safety_macro::Memo(Align, memo = "precond::Align(len, C::BASE_PAGE_SIZE)")]
+    #[safety::Memo(Align, memo = "precond::Align(len, C::BASE_PAGE_SIZE)")]
     // #[safety::precond::Align(len, C::BASE_PAGE_SIZE)]
     pub unsafe fn protect_next(
         &mut self,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -445,7 +445,6 @@ impl<'rcu, C: PageTableConfig> CursorMut<'rcu, C> {
     /// The caller should ensure that
     ///  - the range being mapped does not affect kernel's memory safety;
     ///  - the physical address to be mapped is valid and safe to use;
-
     pub unsafe fn map(&mut self, item: C::Item) -> Result<(), PageTableFrag<C>> {
         assert!(self.0.va < self.0.barrier_va.end);
         let (pa, level, prop) = C::item_into_raw(item);

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -360,7 +360,8 @@ impl PageTable<KernelPtConfig> {
     ///
     /// The caller must ensure that the protection operation does not affect
     /// the memory safety of the kernel.
-    #[safety::precond::ProtectMemorySafe(vaddr)]
+    #[safety_macro::Memo(ProtectMemorySafe, memo = "precond::ProtectMemorySafe(vaddr)")]
+    // #[safety::precond::ProtectMemorySafe(vaddr)]
     pub unsafe fn protect_flush_tlb(
         &self,
         vaddr: &Range<Vaddr>,
@@ -388,7 +389,8 @@ impl<C: PageTableConfig> PageTable<C> {
         }
     }
 
-    #[safety::global::CallOnce]
+    #[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+    // #[safety::global::CallOnce]
     pub(in crate::mm) unsafe fn first_activate_unchecked(&self) {
         // SAFETY: The safety is upheld by the caller.
         unsafe { self.root.first_activate() };
@@ -442,7 +444,8 @@ impl<C: PageTableConfig> PageTable<C> {
     /// Create a new reference to the same page table.
     /// The caller must ensure that the kernel page table is not copied.
     /// This is only useful for IOMMU page tables. Think twice before using it in other cases.
-    #[safety::precond::Uncoppied(self)]
+    #[safety_macro::Memo(Uncoppied, memo = "precond::Uncoppied(self)")]
+    // #[safety::precond::Uncoppied(self)]
     pub unsafe fn shallow_copy(&self) -> Self {
         PageTable {
             root: self.root.clone(),
@@ -579,7 +582,8 @@ pub trait PageTableEntryTrait:
 /// # Safety
 ///
 /// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
-#[safety::precond::SameAs(AtomicUsize::from_ptr)]
+#[safety_macro::Memo(SameAs, memo = "precond::SameAs(AtomicUsize::from_ptr)")]
+// #[safety::precond::SameAs(AtomicUsize::from_ptr)]
 pub unsafe fn load_pte<E: PageTableEntryTrait>(ptr: *mut E, ordering: Ordering) -> E {
     // SAFETY: The safety is upheld by the caller.
     let atomic = unsafe { AtomicUsize::from_ptr(ptr.cast()) };
@@ -592,7 +596,8 @@ pub unsafe fn load_pte<E: PageTableEntryTrait>(ptr: *mut E, ordering: Ordering) 
 /// # Safety
 ///
 /// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
-#[safety::precond::SameAs(AtomicUsize::from_ptr)]
+#[safety_macro::Memo(SameAs, memo = "precond::SameAs(AtomicUsize::from_ptr)")]
+// #[safety::precond::SameAs(AtomicUsize::from_ptr)]
 pub unsafe fn store_pte<E: PageTableEntryTrait>(ptr: *mut E, new_val: E, ordering: Ordering) {
     let new_raw = new_val.as_usize();
     // SAFETY: The safety is upheld by the caller.

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -360,7 +360,7 @@ impl PageTable<KernelPtConfig> {
     ///
     /// The caller must ensure that the protection operation does not affect
     /// the memory safety of the kernel.
-    #[safety_macro::Memo(ProtectMemorySafe, memo = "precond::ProtectMemorySafe(vaddr)")]
+    #[safety::Memo(ProtectMemorySafe, memo = "precond::ProtectMemorySafe(vaddr)")]
     // #[safety::precond::ProtectMemorySafe(vaddr)]
     pub unsafe fn protect_flush_tlb(
         &self,
@@ -389,7 +389,7 @@ impl<C: PageTableConfig> PageTable<C> {
         }
     }
 
-    #[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+    #[safety::Memo(CallOnce, memo = "global::CallOnce")]
     // #[safety::global::CallOnce]
     pub(in crate::mm) unsafe fn first_activate_unchecked(&self) {
         // SAFETY: The safety is upheld by the caller.
@@ -444,7 +444,7 @@ impl<C: PageTableConfig> PageTable<C> {
     /// Create a new reference to the same page table.
     /// The caller must ensure that the kernel page table is not copied.
     /// This is only useful for IOMMU page tables. Think twice before using it in other cases.
-    #[safety_macro::Memo(Uncoppied, memo = "precond::Uncoppied(self)")]
+    #[safety::Memo(Uncoppied, memo = "precond::Uncoppied(self)")]
     // #[safety::precond::Uncoppied(self)]
     pub unsafe fn shallow_copy(&self) -> Self {
         PageTable {
@@ -582,7 +582,7 @@ pub trait PageTableEntryTrait:
 /// # Safety
 ///
 /// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
-#[safety_macro::Memo(SameAs, memo = "precond::SameAs(AtomicUsize::from_ptr)")]
+#[safety::Memo(SameAs, memo = "precond::SameAs(AtomicUsize::from_ptr)")]
 // #[safety::precond::SameAs(AtomicUsize::from_ptr)]
 pub unsafe fn load_pte<E: PageTableEntryTrait>(ptr: *mut E, ordering: Ordering) -> E {
     // SAFETY: The safety is upheld by the caller.
@@ -596,7 +596,7 @@ pub unsafe fn load_pte<E: PageTableEntryTrait>(ptr: *mut E, ordering: Ordering) 
 /// # Safety
 ///
 /// The safety preconditions are same as those of [`AtomicUsize::from_ptr`].
-#[safety_macro::Memo(SameAs, memo = "precond::SameAs(AtomicUsize::from_ptr)")]
+#[safety::Memo(SameAs, memo = "precond::SameAs(AtomicUsize::from_ptr)")]
 // #[safety::precond::SameAs(AtomicUsize::from_ptr)]
 pub unsafe fn store_pte<E: PageTableEntryTrait>(ptr: *mut E, new_val: E, ordering: Ordering) {
     let new_raw = new_val.as_usize();

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -48,9 +48,9 @@ impl<C: PageTableConfig> Child<C> {
     ///  - must not be referenced by a living [`ChildRef`].
     ///
     /// The level must match the original level of the child.
-    #[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(pte)")]
+    #[safety::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(pte)")]
     // #[safety::global::TaggedCallOnce(pte)]
-    #[safety_macro::Memo(NoChildRef, memo = "precond::NoChildRef(pte)")]
+    #[safety::Memo(NoChildRef, memo = "precond::NoChildRef(pte)")]
     // #[safety::precond::NoChildRef(pte)]
     pub(super) unsafe fn from_pte(pte: C::E, level: PagingLevel) -> Self {
         if !pte.is_present() {
@@ -94,9 +94,9 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
     ///
     /// The provided level must be the same with the level of the page table
     /// node that contains this PTE.
-    #[safety_macro::Memo(PteLevelMatch, memo = "precond::PteLevelMatch(level)")]
+    #[safety::Memo(PteLevelMatch, memo = "precond::PteLevelMatch(level)")]
     // #[safety::precond::PteLevelMatch(level)]
-    #[safety_macro::Memo(ChildRefOutLive, memo = "precond::ChildRefOutLive(ReturnValue)")]
+    #[safety::Memo(ChildRefOutLive, memo = "precond::ChildRefOutLive(ReturnValue)")]
     // #[safety::precond::ChildRefOutLive(ReturnValue)]
     pub(super) unsafe fn from_pte(pte: &C::E, level: PagingLevel) -> Self {
         if !pte.is_present() {

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -48,8 +48,10 @@ impl<C: PageTableConfig> Child<C> {
     ///  - must not be referenced by a living [`ChildRef`].
     ///
     /// The level must match the original level of the child.
-    #[safety::global::TaggedCallOnce(pte)]
-    #[safety::precond::NoChildRef(pte)]
+    #[safety_macro::Memo(TaggedCallOnce, memo = "global::TaggedCallOnce(pte)")]
+    // #[safety::global::TaggedCallOnce(pte)]
+    #[safety_macro::Memo(NoChildRef, memo = "precond::NoChildRef(pte)")]
+    // #[safety::precond::NoChildRef(pte)]
     pub(super) unsafe fn from_pte(pte: C::E, level: PagingLevel) -> Self {
         if !pte.is_present() {
             return Child::None;
@@ -92,8 +94,10 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
     ///
     /// The provided level must be the same with the level of the page table
     /// node that contains this PTE.
-    #[safety::precond::PteLevelMatch(level)]
-    #[safety::precond::ChildRefOutLive(ReturnValue)]
+    #[safety_macro::Memo(PteLevelMatch, memo = "precond::PteLevelMatch(level)")]
+    // #[safety::precond::PteLevelMatch(level)]
+    #[safety_macro::Memo(ChildRefOutLive, memo = "precond::ChildRefOutLive(ReturnValue)")]
+    // #[safety::precond::ChildRefOutLive(ReturnValue)]
     pub(super) unsafe fn from_pte(pte: &C::E, level: PagingLevel) -> Self {
         if !pte.is_present() {
             return ChildRef::None;

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -216,7 +216,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
     /// # Safety
     ///
     /// The caller must ensure that the index is within the bounds of the node.
-    #[safety_macro::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(guard, idx)")]
+    #[safety::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(guard, idx)")]
     // #[safety::precond::PteIndexBounded(guard, idx)]
     pub(super) unsafe fn new_at(guard: &'a mut PageTableGuard<'rcu, C>, idx: usize) -> Self {
         // SAFETY: The index is within the bound.

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -216,7 +216,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
     /// # Safety
     ///
     /// The caller must ensure that the index is within the bounds of the node.
-    #[safety::precond::PteIndexBounded(guard, idx)]
+    #[safety_macro::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(guard, idx)")]
+    // #[safety::precond::PteIndexBounded(guard, idx)]
     pub(super) unsafe fn new_at(guard: &'a mut PageTableGuard<'rcu, C>, idx: usize) -> Self {
         // SAFETY: The index is within the bound.
         let pte = unsafe { guard.read_pte(idx) };

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -95,7 +95,8 @@ impl<C: PageTableConfig> PageTableNode<C> {
     /// # Panics
     ///
     /// Only top-level page tables can be activated using this function.
-    #[safety::precond::ProperMapping(self)]
+    #[safety_macro::Memo(ProperMapping, memo = "precond::ProperMapping(self)")]
+    // #[safety::precond::ProperMapping(self)]
     pub(crate) unsafe fn activate(&self) {
         use crate::{
             arch::mm::{activate_page_table, current_page_table_paddr},
@@ -121,7 +122,8 @@ impl<C: PageTableConfig> PageTableNode<C> {
     ///
     /// It will not try dropping the last activate page table. It is the same
     /// with [`Self::activate()`] in other senses.
-    #[safety::global::CallOnce]
+    #[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+    // #[safety::global::CallOnce]
     pub(super) unsafe fn first_activate(&self) {
         use crate::{arch::mm::activate_page_table, mm::CachePolicy};
 
@@ -163,7 +165,8 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
     ///
     /// Calling this function when a guard is already created is undefined behavior
     /// unless that guard was already forgotten.
-    #[safety::precond::LockHeld]
+    #[safety_macro::Memo(LockHeld, memo = "precond::LockHeld")]
+    // #[safety::precond::LockHeld]
     pub(super) unsafe fn make_guard_unchecked<'rcu>(
         self,
         _guard: &'rcu dyn InAtomicMode,
@@ -215,7 +218,8 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     /// # Safety
     ///
     /// The caller must ensure that the index is within the bound.
-    #[safety::precond::PteIndexBounded(self, idx)]
+    #[safety_macro::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(self, idx")]
+    // #[safety::precond::PteIndexBounded(self, idx)]
     pub(super) unsafe fn read_pte(&self, idx: usize) -> C::E {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         let ptr = paddr_to_vaddr(self.start_paddr()) as *mut C::E;
@@ -237,9 +241,12 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     ///     and at the right paging level (`self.level() - 1`).
     ///  3. The page table node will have the ownership of the [`Child`]
     ///     after this method.
-    #[safety::precond::PteIndexBounded(self, idx)]
-    #[safety::precond::PteLevelChild(self, pte)]
-    #[safety::postcond::PteOwned(self, pte)]
+    #[safety_macro::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(self, idx)")]
+    // #[safety::precond::PteIndexBounded(self, idx)]
+    #[safety_macro::Memo(PteLevelChild, memo = "precond::PteLevelChild(self, pte)")]
+    // #[safety::precond::PteLevelChild(self, pte)]
+    #[safety_macro::Memo(PteOwned, memo = "postcond::PteOwned(self, pte)")]
+    // #[safety::postcond::PteOwned(self, pte)]
     pub(super) unsafe fn write_pte(&mut self, idx: usize, pte: C::E) {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
         let ptr = paddr_to_vaddr(self.start_paddr()) as *mut C::E;

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -95,7 +95,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
     /// # Panics
     ///
     /// Only top-level page tables can be activated using this function.
-    #[safety_macro::Memo(ProperMapping, memo = "precond::ProperMapping(self)")]
+    #[safety::Memo(ProperMapping, memo = "precond::ProperMapping(self)")]
     // #[safety::precond::ProperMapping(self)]
     pub(crate) unsafe fn activate(&self) {
         use crate::{
@@ -122,7 +122,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
     ///
     /// It will not try dropping the last activate page table. It is the same
     /// with [`Self::activate()`] in other senses.
-    #[safety_macro::Memo(CallOnce, memo = "global::CallOnce")]
+    #[safety::Memo(CallOnce, memo = "global::CallOnce")]
     // #[safety::global::CallOnce]
     pub(super) unsafe fn first_activate(&self) {
         use crate::{arch::mm::activate_page_table, mm::CachePolicy};
@@ -165,7 +165,7 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
     ///
     /// Calling this function when a guard is already created is undefined behavior
     /// unless that guard was already forgotten.
-    #[safety_macro::Memo(LockHeld, memo = "precond::LockHeld")]
+    #[safety::Memo(LockHeld, memo = "precond::LockHeld")]
     // #[safety::precond::LockHeld]
     pub(super) unsafe fn make_guard_unchecked<'rcu>(
         self,
@@ -218,7 +218,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     /// # Safety
     ///
     /// The caller must ensure that the index is within the bound.
-    #[safety_macro::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(self, idx")]
+    #[safety::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(self, idx")]
     // #[safety::precond::PteIndexBounded(self, idx)]
     pub(super) unsafe fn read_pte(&self, idx: usize) -> C::E {
         debug_assert!(idx < nr_subpage_per_huge::<C>());
@@ -241,11 +241,11 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     ///     and at the right paging level (`self.level() - 1`).
     ///  3. The page table node will have the ownership of the [`Child`]
     ///     after this method.
-    #[safety_macro::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(self, idx)")]
+    #[safety::Memo(PteIndexBounded, memo = "precond::PteIndexBounded(self, idx)")]
     // #[safety::precond::PteIndexBounded(self, idx)]
-    #[safety_macro::Memo(PteLevelChild, memo = "precond::PteLevelChild(self, pte)")]
+    #[safety::Memo(PteLevelChild, memo = "precond::PteLevelChild(self, pte)")]
     // #[safety::precond::PteLevelChild(self, pte)]
-    #[safety_macro::Memo(PteOwned, memo = "postcond::PteOwned(self, pte)")]
+    #[safety::Memo(PteOwned, memo = "postcond::PteOwned(self, pte)")]
     // #[safety::postcond::PteOwned(self, pte)]
     pub(super) unsafe fn write_pte(&mut self, idx: usize, pte: C::E) {
         debug_assert!(idx < nr_subpage_per_huge::<C>());

--- a/ostd/src/smp.rs
+++ b/ostd/src/smp.rs
@@ -81,7 +81,7 @@ cpu_local! {
 }
 
 // #[concur::ctxt(irq)]
-#[safety_macro::Memo(Irq)]
+#[safety::Memo(Irq)]
 fn do_inter_processor_call(_trapframe: &TrapFrame) {
     // No races because we are in IRQs.
     let this_cpu_id = crate::cpu::CpuId::current_racy();

--- a/ostd/src/smp.rs
+++ b/ostd/src/smp.rs
@@ -80,7 +80,8 @@ cpu_local! {
     static CALL_QUEUES: SpinLock<VecDeque<fn()>> = SpinLock::new(VecDeque::new());
 }
 
-#[concur::ctxt(irq)]
+// #[concur::ctxt(irq)]
+#[safety_macro::Memo(Irq)]
 fn do_inter_processor_call(_trapframe: &TrapFrame) {
     // No races because we are in IRQs.
     let this_cpu_id = crate::cpu::CpuId::current_racy();

--- a/ostd/src/task/preempt/guard.rs
+++ b/ostd/src/task/preempt/guard.rs
@@ -7,7 +7,7 @@ use crate::{sync::GuardTransfer, task::atomic_mode::InAtomicMode};
 #[must_use]
 #[derive(Debug)]
 // #[concur::lock(no_preempt)]
-// #[safety_macro::Memo(LockNoInterrupt)] // FIXME: support safety attr on struct
+// #[safety::Memo(LockNoInterrupt)] // FIXME: support safety attr on struct
 pub struct DisabledPreemptGuard {
     // This private field prevents user from constructing values of this type directly.
     _private: (),

--- a/ostd/src/task/preempt/guard.rs
+++ b/ostd/src/task/preempt/guard.rs
@@ -6,7 +6,8 @@ use crate::{sync::GuardTransfer, task::atomic_mode::InAtomicMode};
 #[clippy::has_significant_drop]
 #[must_use]
 #[derive(Debug)]
-#[concur::lock(no_preempt)]
+// #[concur::lock(no_preempt)]
+// #[safety_macro::Memo(LockNoInterrupt)] // FIXME: support safety attr on struct
 pub struct DisabledPreemptGuard {
     // This private field prevents user from constructing values of this type directly.
     _private: (),

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -224,7 +224,8 @@ pub fn disable_local() -> DisabledLocalIrqGuard {
 #[clippy::has_significant_drop]
 #[must_use]
 #[derive(Debug)]
-#[concur::lock(no_interrupt)]
+// #[concur::lock(no_interrupt)]
+// #[safety_macro::Memo(LockNoInterrupt)] // FIXME: support safety attr on struct
 pub struct DisabledLocalIrqGuard {
     was_enabled: bool,
 }

--- a/ostd/src/trap/irq.rs
+++ b/ostd/src/trap/irq.rs
@@ -225,7 +225,7 @@ pub fn disable_local() -> DisabledLocalIrqGuard {
 #[must_use]
 #[derive(Debug)]
 // #[concur::lock(no_interrupt)]
-// #[safety_macro::Memo(LockNoInterrupt)] // FIXME: support safety attr on struct
+// #[safety::Memo(LockNoInterrupt)] // FIXME: support safety attr on struct
 pub struct DisabledLocalIrqGuard {
     was_enabled: bool,
 }


### PR DESCRIPTION
This PR
* imports safety-lib to support `#[safety]` attributes
  * since all attributes are undetermined yet, all `#[safety::precond]`-like attrs are replaced by `#[safety::Memo]`
  * cc https://github.com/Artisan-Lab/tag-std/pull/22
* adds `make rapx` command to check ostd crate with cargo-safety-tool
  * `RAPX_EXIT_AND_EMIT` can be used to control how missing disharges are reported. See [ExitAndEmit](https://github.com/os-checker/tag-std/blob/64edf00d315219b3dc2691752fe13a23ac10a1be/safety-tool/src/analyze_hir/diagnostic.rs#L26-L56) for more info.